### PR TITLE
Covert tags to lowercase

### DIFF
--- a/src/main/word-cloud.js
+++ b/src/main/word-cloud.js
@@ -33,6 +33,7 @@ const text = document.body.innerText.replace(/\s/g, " ").replace(/[^\sa-zA-Z0-9+
  */
 const words = text
   .filter((word) => word.length >= 4)
+  .map((word) => word.toLowerCase())
   .sort();
 
 /**


### PR DESCRIPTION
This commit fixes a bug where tags are sorted incorrectly, due to some
tags being prefixed with capital letters, whilst others are not.

See: #1